### PR TITLE
Adding a default message for embargo notification block

### DIFF
--- a/config/install/embargoes.settings.yml
+++ b/config/install/embargoes.settings.yml
@@ -2,3 +2,4 @@
 embargo_contact_email: null
 add_contact_to_notifications: true
 show_embargo_message: true
+embargo_notification_message: 'Access to this resource is restricted.'


### PR DESCRIPTION
As the embargoes module provides a [notification message block](https://github.com/discoverygarden/embargoes/blob/8.x-1.x/src/Plugin/Block/EmbargoesEmbargoNotificationBlock.php#L17).

By default the contact email is null and the message `embargo_notification_message` is excluded. When rendered, Drupal attempts to provide translatable markup. As null on embargo_notification_message is not a string, drupal return the following error message. Let's just provide a generic message.
```log
InvalidArgumentException: $string ("") must be a string. in Drupal\Core\StringTranslation\TranslatableMarkup->__construct() (line 132 of /opt/www/drupal/core/lib/Drupal/Core/StringTranslation/TranslatableMarkup.php).
```