### PR TITLE
Fix for missing entity configuration in Drupal 9

### DIFF
--- a/src/Entity/EmbargoesEmbargoEntity.php
+++ b/src/Entity/EmbargoesEmbargoEntity.php
@@ -30,6 +30,20 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label" = "label",
  *     "uuid" = "uuid"
  *   },
+ *   config_export = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "embargo_type" = "embargo_type",
+ *     "expiration_type" = "expiration_type",
+ *     "expiration_date" = "expiration_date",
+ *     "exempt_ips" = "exempt_ips",
+ *     "exempt_users" = "exempt_users",
+ *     "additional_emails" = "additional_emails",
+ *     "notification_status" = "notification_status",
+ *     "embargoed_node" = "embargoed_node",
+ *     "notification_status" = "notification_status",
+ *   },
  *   links = {
  *     "canonical" = "/admin/config/content/embargoes/settings/embargoes/{embargoes_embargo_entity}",
  *     "add-form" = "/admin/config/content/embargoes/settings/embargoes/add",

--- a/src/Entity/EmbargoesIpRangeEntity.php
+++ b/src/Entity/EmbargoesIpRangeEntity.php
@@ -29,6 +29,13 @@ use Drupal\Core\Config\Entity\ConfigEntityBase;
  *     "label" = "label",
  *     "uuid" = "uuid"
  *   },
+ *   config_export = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "ranges" = "ranges",
+ *     "proxy_url" = "proxy_url",
+ *   },
  *   links = {
  *     "canonical" = "/admin/config/content/embargoes/settings/ips/{embargoes_ip_range_entity}",
  *     "add-form" = "/admin/config/content/embargoes/settings/ips/add",


### PR DESCRIPTION
```
Drupal\Core\Config\Schema\SchemaIncompleteException: Entity type 'Drupal\embargoes\Entity\EmbargoesEmbargoEntity' is missing 'config_export' definition in its annotation
```